### PR TITLE
Send encoded result images in the response

### DIFF
--- a/dispersal/GPModel/GPM_django_PF.py
+++ b/dispersal/GPModel/GPM_django_PF.py
@@ -3,6 +3,7 @@ from __future__ import division
 import os
 import math
 import json
+import base64
 import requests
 import argparse
 import matplotlib
@@ -84,6 +85,9 @@ def graph_2D(allXs,allYs,allCs,stabilityclass,u,time):
     plt.title('Stability class %s. Wind speed: %s m/s' % (stabilityclass,u))
     plt.savefig('dispersal/static/images/results2D_{}.png'.format(time))
     plt.clf()
+    with open(f'dispersal/static/images/results2D_{time}.png', "rb") as img:
+        str_img = base64.b64encode(img.read())
+        return str_img
 
 def graph_3D(allXs,allYs,allZs,allCs, stability_class,u,time):
     fig = plt.figure()
@@ -162,7 +166,7 @@ def runmodel(graph,H,Q,u,I,R,clouds,stabilityclasses):
                 allXs.append(x)
 
 
-        graph_2D(allXs,allYs,allCs,stabilityclass,u,time)
+        str_img=graph_2D(allXs,allYs,allCs,stabilityclass,u,time)
 
         Ccum = np.cumsum(allCs)
         max99=max(Ccum)*0.999
@@ -183,5 +187,5 @@ def runmodel(graph,H,Q,u,I,R,clouds,stabilityclasses):
                     Xmax=round(x,2)
                     break
 
-        maxdistances[time]=[X95,X75,X50,X99,Xmax]
+        maxdistances[time]=[X95,X75,X50,X99,Xmax,str_img]
     return maxdistances

--- a/dispersal/templates/dispersal/results.html
+++ b/dispersal/templates/dispersal/results.html
@@ -26,10 +26,13 @@
 
 <div class="form-row">
     <div class="form-group col-md-6 mb-0">
-        <img src="{% static 'images/results2D_Day.png' %}" alt="Results">
+        <!-- <img src="{% static 'images/results2D_Day.png' %}" alt="Results"> -->
+        <img src="data:image/png;base64, {{imgday}}" alt="ResultsDay"/>
     </div>
     <div class="form-group col-md-6 mb-0">
-        <img src="{% static 'images/results2D_Night.png' %}" alt="Results">
+        <!-- <img src="{% static 'images/results2D_Night.png' %}" alt="ResultsNight"> -->
+        <img src="data:image/png;base64, {{imgnight}}" alt="ResultsNight"/>
+
     </div>
 </div>
 

--- a/dispersal/views.py
+++ b/dispersal/views.py
@@ -93,7 +93,8 @@ def results(request):
                     'XminD': maxdistances['Day'][4],'XminN': maxdistances['Night'][4],
                     'X95d': maxdistances['Day'][0],'X75d': maxdistances['Day'][1],
                     'X50d': maxdistances['Day'][2],'X95n': maxdistances['Night'][0],
-                    'X75n': maxdistances['Night'][1],'X50n': maxdistances['Night'][2]}
+                    'X75n': maxdistances['Night'][1],'X50n': maxdistances['Night'][2],
+                    'imgday': maxdistances['Day'][5].decode('utf-8'),'imgnight':maxdistances['Night'][5].decode('utf-8')}
             return render(request, 'dispersal/results.html', context)
         else:
             print('form no valid')


### PR DESCRIPTION
Images produced as a result of the model are sent in the response (b64 encoded) instead of saved
-Changed model to send images as b64 object
-Changed views to deal with b64 images in the response
-Changed HTML template to display images
